### PR TITLE
[RF-2123] Updated submit button styles

### DIFF
--- a/client/app/create-beneficiary.component.html
+++ b/client/app/create-beneficiary.component.html
@@ -107,23 +107,25 @@
       </div>
     </div>
 
-    <button
-        type="submit"
-        [disabled]="!form.valid"
-        mat-flat-button
-        color="primary">
-      <span *ngIf="!loading; else loader">
+    <div class="submit-container">
+      <button
+          type="submit"
+          [disabled]="!form.valid"
+          mat-flat-button
+          color="primary">
+      <ng-container *ngIf="!loading; else loader">
         <span>Submit</span>
         <mat-icon>east</mat-icon>
-      </span>
-      <ng-template #loader>
-        <mat-progress-spinner mode="indeterminate" [diameter]="26"></mat-progress-spinner>
-      </ng-template>
-    </button>
-    <div *ngIf="!form.valid && form.touched && form.enabled" class="mat-caption">
-      Please fill all required fields.
-      <div>
-        Required fields are marked with *.
+      </ng-container>
+        <ng-template #loader>
+          <mat-progress-spinner mode="indeterminate" [diameter]="26"></mat-progress-spinner>
+        </ng-template>
+      </button>
+      <div *ngIf="!form.valid && form.touched && form.enabled" class="mat-caption">
+        Please fill all required fields.
+        <div>
+          Required fields are marked with *.
+        </div>
       </div>
     </div>
   </form>

--- a/client/app/create-beneficiary.component.scss
+++ b/client/app/create-beneficiary.component.scss
@@ -120,14 +120,19 @@
       margin-top: 48px;
     }
 
+    .submit-container {
+      text-align: center;
+      width: 220px;
+      margin-top: 48px;
+    }
+
     button[type="submit"] {
       $height: 56px;
       display: flex;
       justify-content: center;
       width: 220px;
       height: $height;
-      padding: 9px;
-      margin: 56px auto 0;
+      padding: 0 24px;
       border-radius: $height / 2;
 
       &:not([disabled]) {
@@ -135,9 +140,15 @@
       }
 
       mat-icon {
-        margin-left: 45px;
-        margin-top: -5px;
         vertical-align: middle;
+      }
+
+      ::ng-deep .mat-button-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        height: 100%;
       }
     }
 

--- a/client/app/create-payment.component.html
+++ b/client/app/create-payment.component.html
@@ -18,23 +18,25 @@
       >
     </mat-form-field>
 
-    <button
-        type="submit"
-        [disabled]="!form.valid"
-        mat-flat-button
-        color="primary">
-      <span *ngIf="!loading; else loader">
+    <div class="submit-container">
+      <button
+          type="submit"
+          [disabled]="!form.valid"
+          mat-flat-button
+          color="primary">
+      <ng-container *ngIf="!loading; else loader">
         <span>Create Payment</span>
         <mat-icon>east</mat-icon>
-      </span>
-      <ng-template #loader>
-        <mat-progress-spinner mode="indeterminate" [diameter]="26"></mat-progress-spinner>
-      </ng-template>
-    </button>
-    <div *ngIf="!form.valid && form.touched && form.enabled" class="mat-caption">
-      Please fill all required fields.
-      <div>
-        Required fields are marked with *.
+      </ng-container>
+        <ng-template #loader>
+          <mat-progress-spinner mode="indeterminate" [diameter]="26"></mat-progress-spinner>
+        </ng-template>
+      </button>
+      <div *ngIf="!form.valid && form.touched && form.enabled" class="mat-caption">
+        Please fill all required fields.
+        <div>
+          Required fields are marked with *.
+        </div>
       </div>
     </div>
   </form>

--- a/client/app/create-payment.component.scss
+++ b/client/app/create-payment.component.scss
@@ -120,14 +120,19 @@
       margin-top: 48px;
     }
 
+    .submit-container {
+      text-align: center;
+      width: 220px;
+      margin-top: 48px;
+    }
+
     button[type="submit"] {
       $height: 56px;
       display: flex;
       justify-content: center;
       width: 220px;
       height: $height;
-      padding: 9px;
-      margin: 56px auto 0;
+      padding: 0 24px;
       border-radius: $height / 2;
 
       &:not([disabled]) {
@@ -135,9 +140,15 @@
       }
 
       mat-icon {
-        margin-left: 45px;
-        margin-top: -5px;
         vertical-align: middle;
+      }
+
+      ::ng-deep .mat-button-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        height: 100%;
       }
     }
 

--- a/client/app/link-loan.component.html
+++ b/client/app/link-loan.component.html
@@ -41,18 +41,20 @@
       </div>
     </div>
 
-    <button
-        type="submit"
-        [disabled]="isSubmitDisabled"
-        mat-flat-button
-        color="primary">
-        <span *ngIf="!loading; else loader">
+    <div class="submit-container">
+      <button
+          type="submit"
+          [disabled]="isSubmitDisabled"
+          mat-flat-button
+          color="primary">
+        <ng-container *ngIf="!loading; else loader">
           <span>Link Loan</span>
           <mat-icon>east</mat-icon>
-        </span>
-      <ng-template #loader>
-        <mat-progress-spinner mode="indeterminate" [diameter]="26"></mat-progress-spinner>
-      </ng-template>
-    </button>
+        </ng-container>
+        <ng-template #loader>
+          <mat-progress-spinner mode="indeterminate" [diameter]="26"></mat-progress-spinner>
+        </ng-template>
+      </button>
+    </div>
   </form>
 </mat-card-content>

--- a/client/app/link-loan.component.scss
+++ b/client/app/link-loan.component.scss
@@ -194,14 +194,19 @@
       margin-top: 48px;
     }
 
+    .submit-container {
+      text-align: center;
+      width: 220px;
+      margin-top: 48px;
+    }
+
     button[type="submit"] {
       $height: 56px;
       display: flex;
       justify-content: center;
       width: 220px;
       height: $height;
-      padding: 9px;
-      margin: 56px auto 0;
+      padding: 0 24px;
       border-radius: $height / 2;
 
       &:not([disabled]) {
@@ -209,9 +214,15 @@
       }
 
       mat-icon {
-        margin-left: 45px;
-        margin-top: -5px;
         vertical-align: middle;
+      }
+
+      ::ng-deep .mat-button-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        height: 100%;
       }
     }
 
@@ -241,7 +252,7 @@
   &-container {
     width: 100%;
     max-width: 376px;
-    margin: 45px 0;
+    margin-top: 45px;
 
     ::ng-deep {
       iframe {
@@ -264,7 +275,8 @@
       display: flex;
       flex-flow: wrap;
 
-      div {
+      .vgs-form-field {
+        margin-bottom: 0;
         flex: 0 0 calc(50% - 14px);
         &:first-of-type {
           margin-right: 28px;


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/59651445/143148783-86d69897-fec6-4345-a1c3-5e84febe0f2d.png)

Now:
<img width="269" alt="Screenshot 2021-11-24 at 02 13 29" src="https://user-images.githubusercontent.com/59651445/143148619-3f305b8b-3080-411c-87c4-0a07d1fbb9df.png">

Of course it's better to have these styles to be defined in one place, but it's a good thing to refactor at a later time!

<pr-train-toc>

#### PR chain:
#74 ([RF-2123] Added .pr-train to .gitignore)
#75 ([RF-2123] Fix styles and a bug for the StepperComponent)
#76 ([RF-2123] Added loan type selector)
#79 ([RF-2123] VGS Collect form)
👉 #80 ([RF-2123] Updated submit button styles) 👈 **YOU ARE HERE**
#81 ([RF-2201] Payment status panel)

</pr-train-toc>

[RF-2123]: https://rightfoot-eng.atlassian.net/browse/RF-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-2123]: https://rightfoot-eng.atlassian.net/browse/RF-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-2123]: https://rightfoot-eng.atlassian.net/browse/RF-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-2123]: https://rightfoot-eng.atlassian.net/browse/RF-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-2123]: https://rightfoot-eng.atlassian.net/browse/RF-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RF-2201]: https://rightfoot-eng.atlassian.net/browse/RF-2201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ